### PR TITLE
portunus: fix user ldap filter containing objectClass twice

### DIFF
--- a/modules/portunus.nix
+++ b/modules/portunus.nix
@@ -189,7 +189,7 @@ in
       searchUID = "search";
       surnameField = "sn";
       userField = "uid";
-      userFilter = replaceStr: "(&(objectclass=person)(|(uid=${replaceStr})(mail=${replaceStr})))";
+      userFilter = replaceStr: "(|(uid=${replaceStr})(mail=${replaceStr}))";
       userBaseDN = "ou=users";
     };
   };


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changted by default
- [x] Tested changes on a real world deployment
