### PR TITLE
zfs: make latestCompatibleKernel not an opinionated option

### DIFF
--- a/modules/zfs.nix
+++ b/modules/zfs.nix
@@ -7,7 +7,7 @@ in
   options = {
     boot.zfs = {
       recommendedDefaults = libS.mkOpinionatedOption "enable recommended ZFS settings";
-      latestCompatibleKernel = libS.mkOpinionatedOption "use the latest ZFS compatible kernel";
+      latestCompatibleKernel = lib.mkEnableOption "use the latest ZFS compatible kernel";
     };
   };
 


### PR DESCRIPTION
The latest kernel has sometimes some nice new features especially for virtiofs but also often bugs and usually does not work nicely with the stable/production nvidia driver.

## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
