### PR TITLE
Drop no longer required override

### DIFF
--- a/modules/no-x-libs.nix
+++ b/modules/no-x-libs.nix
@@ -3,8 +3,7 @@
 # this module extends the environment.noXlibs setting with yet to merge and upstream overwrites
 {
   config = lib.mkIf config.environment.noXlibs {
-    nixpkgs.overlays = lib.singleton (lib.const (super: {
-      nginx = super.nginx.override { withImageFilter = false; };
-    }));
+    # nixpkgs.overlays = lib.singleton (lib.const (super: {
+    # }));
   };
 }


### PR DESCRIPTION
The option was only introduced in https://github.com/NixOS/nixpkgs/pull/313844

I wonder how that ever worked. Maybe I cherry-picked things from that PR and they already rebased out of my fork and in the review they changed the default from true to false.