### PR TITLE
postgres: create refreshCollation option, add user password option

### DIFF
--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -13,7 +13,7 @@ in
       description = ''
         List of all databases.
 
-        This option is used eg. when intalling extensions like pg_stat_stements in all databases.
+        This option is used eg. when installing extensions like pg_stat_stements in all databases.
 
         ::: {.note}
         `services.postgresql.ensureDatabases` and `postgres` are automatically added.
@@ -120,7 +120,7 @@ in
         '') (lib.splitString "," cfg.settings.shared_preload_libraries)))
         cfg.databases));
 
-      # reduce downtime for dependend services
+      # reduce downtime for dependent services
       stopIfChanged = lib.mkIf cfg.recommendedDefaults false;
     };
   };

--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -23,6 +23,8 @@ in
 
     recommendedDefaults = libS.mkOpinionatedOption "set recommended default settings";
 
+    refreshCollation = libS.mkOpinionatedOption "refresh collation on startup. This prevents errors when initializing new DBs after a glibc upgrade";
+
     upgrade = {
       enable = libS.mkOpinionatedOption "install the upgrade-pg-cluster script to update postgres";
 
@@ -111,14 +113,30 @@ in
     };
 
     systemd.services.postgresql = {
-      # install/update pg_stat_statements extension in all databases
-      # based on https://git.catgirl.cloud/999eagle/dotfiles-nix/-/blob/main/modules/system/server/postgres/default.nix#L294-302
-      postStart = lib.mkIf cfg.configurePgStatStatements (lib.concatStrings (map (db:
-        (lib.concatMapStringsSep "\n" (ext: /* bash */ ''
-          $PSQL -tAd "${db}" -c "CREATE EXTENSION IF NOT EXISTS ${ext}"
-          $PSQL -tAd "${db}" -c "ALTER EXTENSION ${ext} UPDATE"
-        '') (lib.splitString "," cfg.settings.shared_preload_libraries)))
-        cfg.databases));
+      postStart = lib.mkMerge [
+        (lib.mkIf cfg.refreshCollation (lib.mkBefore /* bash */ ''
+          # copied from upstream due to the lack of extensibility
+          # TODO: improve this upstream?
+          PSQL="psql --port=${toString cfg.settings.port}"
+
+          while ! $PSQL -d postgres -c "" 2> /dev/null; do
+            if ! kill -0 "$MAINPID"; then exit 1; fi
+            sleep 0.1
+          done
+
+          $PSQL -tAc 'ALTER DATABASE template1 REFRESH COLLATION VERSION'
+        ''))
+
+        # install/update pg_stat_statements extension in all databases
+        # based on https://git.catgirl.cloud/999eagle/dotfiles-nix/-/blob/main/modules/system/server/postgres/default.nix#L294-302
+        (lib.mkIf cfg.configurePgStatStatements (lib.concatStrings (map (db:
+          (lib.concatMapStringsSep "\n" (ext: /* bash */ ''
+            $PSQL -tAd "${db}" -c "CREATE EXTENSION IF NOT EXISTS ${ext}"
+            $PSQL -tAd "${db}" -c "ALTER EXTENSION ${ext} UPDATE"
+          '') (lib.splitString "," cfg.settings.shared_preload_libraries)))
+          cfg.databases))
+        )
+      ];
 
       # reduce downtime for dependent services
       stopIfChanged = lib.mkIf cfg.recommendedDefaults false;


### PR DESCRIPTION
@MarcelCoding can you test this on your config?

I've tested the refresh collation on a server and it worked as expected:

```
postgresql-post-start[123456]: NOTICE:  changing version from 2.38 to 2.39
```

## Things done

- [x] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
