### PR TITLE
gitea: sync ssh keys on startup.

### DIFF
--- a/modules/gitea.nix
+++ b/modules/gitea.nix
@@ -171,6 +171,11 @@ in
       };
       "cron.delete_old_actions".ENABLED = true;
       "cron.delete_old_system_notices".ENABLED = true;
+      # TODO: upstream?
+      "cron.resync_all_sshkeys" = {
+        ENABLED = true;
+        RUN_AT_START = true;
+      };
       other.SHOW_FOOTER_VERSION = false;
       repository.ACCESS_CONTROL_ALLOW_ORIGIN = cfg.settings.server.DOMAIN;
       "repository.signing".DEFAULT_TRUST_MODEL = "committer";


### PR DESCRIPTION
The gitea command in the authorized_keys file might have changed

## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
