### PR TITLE
harmonia: disable nginx by default

### DIFF
--- a/modules/harmonia.nix
+++ b/modules/harmonia.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     services.harmonia = {
-      configureNginx = libS.mkOpinionatedOption "configure nginx";
+      configureNginx = lib.mkEnableOption "configure nginx for harmonia";
 
       domain = lib.mkOption {
         type = lib.types.str;


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
