### PR TITLE
grafana: fix admin password assertion

### DIFF
--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -48,7 +48,7 @@ in
         message = "services.grafana.settings.security.secret_key must be changed from it's insecure, default value!";
       }
       {
-        assertion = cfg.settings.security.admin_password != "admin";
+        assertion = cfg.settings.security.disable_initial_admin_creation || cfg.settings.security.admin_password != "admin";
         message = "services.grafana.settings.security.admin_password must be changed from it's insecure, default value!";
       }
     ];


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
