### PR TITLE
ldap: drop useless types.submodule

### DIFF
--- a/modules/ldap.nix
+++ b/modules/ldap.nix
@@ -4,158 +4,152 @@ let
   cfg = config.security.ldap;
 in
 {
-  options.security.ldap = lib.mkOption {
-    type = lib.types.submodule {
-      options = {
-        bindDN = lib.mkOption {
-          type = with lib.types; nullOr str;
-          example = "uid=search";
-          default = if cfg.searchUID != null then "uid=${cfg.searchUID}" else null;
-          apply = s: s + "," + cfg.userBaseDN;
-          description = ''
-            The DN of the service user used by services.
-            The user base dn will be automatically appended.
-          '';
-        };
-
-        domainComponent = lib.mkOption {
-          type = with lib.types; listOf str;
-          example = [ "example" "com" ];
-          apply = dc: lib.removeSuffix "," (lib.concatMapStrings (x: "dc=${x},") dc);
-          description = ''
-            Domain component(s) (dc) represented as a list of strings.
-
-            Each entry will be prefixed with `dc=` and all are concatinated with `,`, except the last one.
-            The example would be concatinated to `dc=example,dc=com`
-          '';
-        };
-
-        domainName = lib.mkOption {
-          type = lib.types.str;
-          example = "auth.internal.example.com";
-          description = "The domain name to connect to the ldap server's ldaps port.";
-        };
-
-        webDomainName = lib.mkOption {
-          type = lib.types.str;
-          example = "auth.example.com";
-          description = "The domain name to connect to, to visit the ldap server web interface and to which to issue cookies to.";
-        };
-
-        givenNameField = lib.mkOption {
-          type = lib.types.str;
-          example = "givenName";
-          description = "The attribute of the user object where to find its given name.";
-        };
-
-        groupFilter = lib.mkOption {
-          type = with lib.types; functionTo str;
-          example = lib.literalExpression ''group: "(&(objectclass=person)(isMemberOf=cn=''${group},''${config.security.ldap.roleBaseDN}"'';
-          description = "A function that returns a group filter that matches the first argument against the names of the groups the user is part of.";
-        };
-
-        mailField = lib.mkOption {
-          type = lib.types.str;
-          example = "mail";
-          description = "The attribute of the user object where to find its email.";
-        };
-
-        port = lib.mkOption {
-          type = lib.types.port;
-          example = "636";
-          description = "The port the ldap server listens on. Usually this is 389 for ldap and 636 for ldaps.";
-        };
-
-        roleBaseDN = lib.mkOption {
-          type = lib.types.str;
-          example = "ou=groups";
-          apply = s: s + "," + cfg.domainComponent;
-          description = ''
-            The directory path where applications should search for users.
-            Domain component will be automatically appended.
-          '';
-        };
-
-        roleField = lib.mkOption {
-          type = lib.types.str;
-          example = "cn";
-          description = "The attribute where the user account is listed in a group.";
-        };
-
-        roleFilter = lib.mkOption {
-          type = lib.types.str;
-          example = "(&(objectclass=groupOfNames)(member=%s))";
-          description = "Filter to get the groups of an user object.";
-        };
-
-        roleValue = lib.mkOption {
-          type = lib.types.str;
-          example = "dn";
-          description = "The attribute of the user object where to find its distinguished name.";
-        };
-
-        searchUID = lib.mkOption {
-          type = with lib.types; nullOr str;
-          default = null;
-          example = "search";
-          description = "The uid of the service user used by services, often referred as search user.";
-        };
-
-        searchFilterWithGroupFilter = lib.mkOption {
-          type = with lib.types; functionTo (functionTo str);
-          example = lib.literalExpression ''userFilterGroup: userFilter: if (userFilterGroup != null) then "(&''${config.security.ldap.groupFilter userFilterGroup})" else userFilter'';
-          description = ''
-            A function that returns a search filter that may include a group filter.
-            The first argument may be the group that is filtered upon or null.
-            If set to null no additional filtering is done. If set the supplied filter is combined with the user filter.
-            The second argument must be the user filter including the applications placeholders or ideally the userFilter option.
-          '';
-        };
-
-        serverURI = lib.mkOption {
-          type = lib.types.str;
-          default = "ldaps://${cfg.domainName}:${toString cfg.port}";
-          defaultText = "ldaps://$''{config.security.ldap.domainName}:$''{config.security.ldap.port}";
-          example = "ldap://$''{config.security.ldap.domainName}";
-          description = "The ldap server URI";
-        };
-
-        sshPublicKeyField = lib.mkOption {
-          type = lib.types.str;
-          example = "sshPublicKey";
-          description = "The attribute of the user object where to find its ssh public key.";
-        };
-
-        surnameField = lib.mkOption {
-          type = lib.types.str;
-          example = "sn";
-          description = "The attribute of the user object where to find its surname.";
-        };
-
-        userBaseDN = lib.mkOption {
-          type = lib.types.str;
-          example = "ou=users";
-          apply = s: s + "," + cfg.domainComponent;
-          description = ''
-            The directory path where applications should search for users.
-            Domain component will be automatically appended.
-          '';
-        };
-
-        userField = lib.mkOption {
-          type = lib.types.str;
-          example = "uid";
-          description = "The attribute of the user object where to find its username.";
-        };
-
-        userFilter = lib.mkOption {
-          type = with lib.types; functionTo str;
-          example = ''param: "(&(objectclass=person)(|(uid=''${param})(mail=''${param})))"'';
-          description = "A function that returns a user search filter that uses the first argument as the placeholder.";
-        };
-      };
+  options.security.ldap = {
+    bindDN = lib.mkOption {
+      type = with lib.types; nullOr str;
+      example = "uid=search";
+      default = if cfg.searchUID != null then "uid=${cfg.searchUID}" else null;
+      apply = s: s + "," + cfg.userBaseDN;
+      description = ''
+        The DN of the service user used by services.
+        The user base dn will be automatically appended.
+      '';
     };
-    default = { };
-    description = "LDAP options used in other services.";
+
+    domainComponent = lib.mkOption {
+      type = with lib.types; listOf str;
+      example = [ "example" "com" ];
+      apply = dc: lib.removeSuffix "," (lib.concatMapStrings (x: "dc=${x},") dc);
+      description = ''
+        Domain component(s) (dc) represented as a list of strings.
+
+        Each entry will be prefixed with `dc=` and all are concatinated with `,`, except the last one.
+        The example would be concatinated to `dc=example,dc=com`
+      '';
+    };
+
+    domainName = lib.mkOption {
+      type = lib.types.str;
+      example = "auth.internal.example.com";
+      description = "The domain name to connect to the ldap server's ldaps port.";
+    };
+
+    webDomainName = lib.mkOption {
+      type = lib.types.str;
+      example = "auth.example.com";
+      description = "The domain name to connect to, to visit the ldap server web interface and to which to issue cookies to.";
+    };
+
+    givenNameField = lib.mkOption {
+      type = lib.types.str;
+      example = "givenName";
+      description = "The attribute of the user object where to find its given name.";
+    };
+
+    groupFilter = lib.mkOption {
+      type = with lib.types; functionTo str;
+      example = lib.literalExpression ''group: "(&(objectclass=person)(isMemberOf=cn=''${group},''${config.security.ldap.roleBaseDN}"'';
+      description = "A function that returns a group filter that matches the first argument against the names of the groups the user is part of.";
+    };
+
+    mailField = lib.mkOption {
+      type = lib.types.str;
+      example = "mail";
+      description = "The attribute of the user object where to find its email.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      example = "636";
+      description = "The port the ldap server listens on. Usually this is 389 for ldap and 636 for ldaps.";
+    };
+
+    roleBaseDN = lib.mkOption {
+      type = lib.types.str;
+      example = "ou=groups";
+      apply = s: s + "," + cfg.domainComponent;
+      description = ''
+        The directory path where applications should search for users.
+        Domain component will be automatically appended.
+      '';
+    };
+
+    roleField = lib.mkOption {
+      type = lib.types.str;
+      example = "cn";
+      description = "The attribute where the user account is listed in a group.";
+    };
+
+    roleFilter = lib.mkOption {
+      type = lib.types.str;
+      example = "(&(objectclass=groupOfNames)(member=%s))";
+      description = "Filter to get the groups of an user object.";
+    };
+
+    roleValue = lib.mkOption {
+      type = lib.types.str;
+      example = "dn";
+      description = "The attribute of the user object where to find its distinguished name.";
+    };
+
+    searchUID = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "search";
+      description = "The uid of the service user used by services, often referred as search user.";
+    };
+
+    searchFilterWithGroupFilter = lib.mkOption {
+      type = with lib.types; functionTo (functionTo str);
+      example = lib.literalExpression ''userFilterGroup: userFilter: if (userFilterGroup != null) then "(&''${config.security.ldap.groupFilter userFilterGroup})" else userFilter'';
+      description = ''
+        A function that returns a search filter that may include a group filter.
+        The first argument may be the group that is filtered upon or null.
+        If set to null no additional filtering is done. If set the supplied filter is combined with the user filter.
+        The second argument must be the user filter including the applications placeholders or ideally the userFilter option.
+      '';
+    };
+
+    serverURI = lib.mkOption {
+      type = lib.types.str;
+      default = "ldaps://${cfg.domainName}:${toString cfg.port}";
+      defaultText = "ldaps://$''{config.security.ldap.domainName}:$''{config.security.ldap.port}";
+      example = "ldap://$''{config.security.ldap.domainName}";
+      description = "The ldap server URI";
+    };
+
+    sshPublicKeyField = lib.mkOption {
+      type = lib.types.str;
+      example = "sshPublicKey";
+      description = "The attribute of the user object where to find its ssh public key.";
+    };
+
+    surnameField = lib.mkOption {
+      type = lib.types.str;
+      example = "sn";
+      description = "The attribute of the user object where to find its surname.";
+    };
+
+    userBaseDN = lib.mkOption {
+      type = lib.types.str;
+      example = "ou=users";
+      apply = s: s + "," + cfg.domainComponent;
+      description = ''
+        The directory path where applications should search for users.
+        Domain component will be automatically appended.
+      '';
+    };
+
+    userField = lib.mkOption {
+      type = lib.types.str;
+      example = "uid";
+      description = "The attribute of the user object where to find its username.";
+    };
+
+    userFilter = lib.mkOption {
+      type = with lib.types; functionTo str;
+      example = ''param: "(&(objectclass=person)(|(uid=''${param})(mail=''${param})))"'';
+      description = "A function that returns a user search filter that uses the first argument as the placeholder.";
+    };
   };
 }


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
