### PR TITLE
containers: drop --external flag

### DIFF
--- a/modules/containers.nix
+++ b/modules/containers.nix
@@ -24,7 +24,6 @@ in
     virtualisation = let
       autoPruneFlags = [
         "--all"
-        "--external"
         "--force"
         "--volumes"
       ];


### PR DESCRIPTION
Error: system prune --external cannot be combined with other options

Also I haven't used anything "external" myself, so don't bother with it for now.

## Things done

- [ ] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
