### PR TITLE
nextcloud: fix Imaginary

### DIFF
--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -188,6 +188,7 @@ in
       };
 
       timers.nextcloud-cron-preview-generator = lib.mkIf cfg.configurePreviewSettings {
+        after = [ "nextcloud-setup.service" ];
         timerConfig = {
           OnCalendar = "*:0/15";
           OnUnitActiveSec = "10m";

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -186,7 +186,10 @@ in
 
       timers.nextcloud-cron-preview-generator = lib.mkIf cfg.configurePreviewSettings {
         timerConfig = {
-          OnUnitActiveSec = "5m";
+          OnCalendar = "*:0/15";
+          OnUnitActiveSec = "10m";
+          Persistent = true;
+          RandomizedDelaySec = 60;
           Unit = "nextcloud-cron-preview-generator.service";
         };
         wantedBy = [ "timers.target" ];

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -70,6 +70,8 @@ in
               # https://docs.nextcloud.com/server/24/admin_manual/installation/server_tuning.html#previews
               ''OC\Preview\Imaginary''
             ];
+
+            preview_imaginary_url = "http://127.0.0.1:${toString config.services.imaginary.port}/";
           })
 
           (lib.mkIf cfg.configureMemories {

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -29,7 +29,13 @@ in
         '';
       };
 
-      configureRecognize = lib.mkEnableOption "" // { description = "Whether to configure dependencies for Recognize App."; };
+      configureRecognize = lib.mkEnableOption "" // { description = ''
+        Whether to configure dependencies for Recognize App.
+
+        ::: {.note}
+        This currently does not work with declerataive installed apps.
+        :::
+      ''; };
     };
   };
 

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -48,12 +48,14 @@ in
       };
 
       nextcloud = {
-        extraApps = lib.mkMerge [
+        extraApps = let
+          inherit (pkgs."nextcloud${lib.versions.major cfg.package.version}Packages") apps;
+        in lib.mkMerge [
           (lib.mkIf cfg.configureMemories {
-            inherit (config.services.nextcloud.package.packages.apps) memories;
+            inherit (apps) memories;
           })
           (lib.mkIf cfg.configurePreviewSettings {
-            inherit (config.services.nextcloud.package.packages.apps) previewgenerator;
+            inherit (apps) previewgenerator;
           })
         ];
 

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -190,8 +190,8 @@ in
       timers.nextcloud-cron-preview-generator = lib.mkIf cfg.configurePreviewSettings {
         after = [ "nextcloud-setup.service" ];
         timerConfig = {
-          OnCalendar = "*:0/15";
-          OnUnitActiveSec = "10m";
+          OnCalendar = "*:0/10";
+          OnUnitActiveSec = "9m";
           Persistent = true;
           RandomizedDelaySec = 60;
           Unit = "nextcloud-cron-preview-generator.service";

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -71,6 +71,7 @@ in
               ''OC\Preview\Imaginary''
             ];
 
+            enable_previews = true;
             preview_imaginary_url = "http://127.0.0.1:${toString config.services.imaginary.port}/";
           })
 

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -42,6 +42,15 @@ in
       };
 
       nextcloud = {
+        extraApps = lib.mkMerge [
+          (lib.mkIf cfg.configureMemories {
+            inherit (config.services.nextcloud.package.packages.apps) memories;
+          })
+          (lib.mkIf cfg.configurePreviewSettings {
+            inherit (config.services.nextcloud.package.packages.apps) previewgenerator;
+          })
+        ];
+
         phpOptions = lib.mkIf cfg.recommendedDefaults {
           # https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html#:~:text=opcache.jit%20%3D%201255%20opcache.jit_buffer_size%20%3D%20128m
           "opcache.jit" = 1255;
@@ -71,7 +80,6 @@ in
               ''OC\Preview\Imaginary''
             ];
 
-            enable_previews = true;
             preview_imaginary_url = "http://127.0.0.1:${toString config.services.imaginary.port}/";
           })
 
@@ -99,6 +107,7 @@ in
               ''OC\Preview\WebP''
             ];
 
+            enable_previews = true;
             jpeg_quality = 60;
             preview_max_filesize_image = 128; # MB
             preview_max_memory = 512; # MB


### PR DESCRIPTION
I missed the chance to test the After= with the nextcloud update but it now matches nextcloud-cron.

## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
