### PR TITLE
slim: drop lvm

### DIFF
--- a/modules/slim.nix
+++ b/modules/slim.nix
@@ -30,16 +30,10 @@ in
     # during testing only 550K-650K of the tmpfs where used
     security.wrapperDirSize = "10M";
 
-    services = lib.mkMerge [
-      {
-        lvm.enable = false;
-      }
-
-      (lib.optionalAttrs (options.services?orca) {
-        orca.enable = false; # requires speechd
-      } // lib.optionalAttrs (options.services?speechd) {
-        speechd.enable = false; # voice files are big and fat
-      })
-    ];
+    services = lib.optionalAttrs (options.services?orca) {
+      orca.enable = false; # requires speechd
+    } // lib.optionalAttrs (options.services?speechd) {
+      speechd.enable = false; # voice files are big and fat
+    };
   });
 }


### PR DESCRIPTION
Retrospectively this was the most stupid decision I did in this repo. lvm2 contains udev rules that allow cryptsetup and zpool scrub to work. This is accompanied by two PRs to nixpkgs to not let other run into this:
https://github.com/NixOS/nixpkgs/pull/355463
https://github.com/NixOS/nixpkgs/pull/355464

## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
