### PR TITLE
prometheus: don't cause error on empty config

### DIFF
--- a/modules/prometheus.nix
+++ b/modules/prometheus.nix
@@ -152,7 +152,7 @@ in
           })
         ) cfgb.httpProbe);
 
-        configFile = lib.mkIf (cfgb.config != { }) (yamlFormat.generate "blackbox-exporter.yaml" cfgb.config);
+        configFile = yamlFormat.generate "blackbox-exporter.yaml" cfgb.config;
       };
 
       ruleFiles = map (rule: yamlFormat.generate "prometheus-rule" rule) cfg.rulesConfig;


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
