### PR TITLE
nginx: allow disabling individual recommended settings without mkForce

### DIFF
--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -137,9 +137,6 @@ in
           error_log syslog:server=unix:/dev/log;
         '' + lib.optionalString cfg.configureQuic /* nginx */''
           quic_retry on;
-        '' + lib.optionalString cfg.recommendedZstdSettings /* nginx */ ''
-          # from harmonia readme
-          zstd_types application/x-nix-archive;
         '';
 
         enableQuicBPF = lib.mkIf cfg.configureQuic true;

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -146,12 +146,12 @@ in
 
         package = lib.mkIf cfg.configureQuic pkgs.nginxQuic; # based on pkgs.nginxMainline
 
-        recommendedBrotliSettings = lib.mkIf cfg.allRecommendOptions true;
-        recommendedGzipSettings = lib.mkIf cfg.allRecommendOptions true;
-        recommendedOptimisation = lib.mkIf cfg.allRecommendOptions true;
-        recommendedProxySettings = lib.mkIf cfg.allRecommendOptions true;
-        recommendedTlsSettings = lib.mkIf cfg.allRecommendOptions true;
-        recommendedZstdSettings = lib.mkIf cfg.allRecommendOptions true;
+        recommendedBrotliSettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
+        recommendedGzipSettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
+        recommendedOptimisation = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
+        recommendedProxySettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
+        recommendedTlsSettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
+        recommendedZstdSettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);
 
         resolver.addresses =
           let


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
