### PR TITLE
 home-assistant: expand recommended default settings, fix eval when home-assistant db_url is not set

### DIFF
--- a/modules/home-assistant.nix
+++ b/modules/home-assistant.nix
@@ -71,6 +71,15 @@ in
           unit_system = "metric";
         };
 
+        recoder = {
+          exclude = {
+            domains = [ "automation" "update" ];
+            entity_globs = [ "sensor.sun*" "weather.*" ];
+            entities = [ "sensor.date" "sensor.last_boot" "sun.sun" ];
+            event_types = [ "call_service" ];
+          };
+        };
+
         # see https://github.com/zigpy/zigpy/pull/1340
         zha.zigpy_config.ota.z2m_remote_index = "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/index.json";
       };

--- a/modules/home-assistant.nix
+++ b/modules/home-assistant.nix
@@ -71,6 +71,7 @@ in
           unit_system = "metric";
         };
 
+        # https://www.home-assistant.io/integrations/recorder/#common-filtering-examples
         recoder = {
           exclude = {
             domains = [ "automation" "update" ];

--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -198,7 +198,7 @@ in
           (lib.mkIf (healthchecks.enable && healthchecks.settings.DB_HOST == "/run/postgresql") [ "healthchecks" ])
           (lib.mkIf (hedgedoc.enable && hedgedoc.settings.db.host == "/run/postgresql") [ "hedgedoc" ])
           # @ means to connect to localhost
-          (lib.mkIf (home-assistant.enable && (lib.hasPrefix "postgresql://@/" home-assistant.config.recorder.db_url)) [ "home-assistant" ])
+          (lib.mkIf (home-assistant.enable && (lib.hasPrefix "postgresql://@/" home-assistant.config.recorder.db_url or "")) [ "home-assistant" ])
           # if host= is omitted, hydra defaults to connect to localhost
           (lib.mkIf (hydra.enable && (!lib.hasInfix ";host=" hydra.dbi)) [
             "hydra-evaluator" "hydra-notify" "hydra-send-stats" "hydra-update-gc-roots" "hydra-queue-runner" "hydra-server"


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
