### PR TITLE
postgres: fix double cfg on pg_stat_statements install

### DIFF
--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -260,7 +260,7 @@ in
 
             # install/update pg_stat_statements extension in all databases
             # based on https://git.catgirl.cloud/999eagle/dotfiles-nix/-/blob/main/modules/system/server/postgres/default.nix#L294-302
-            (lib.mkIf (cfg.enableAllPreloadedLibraries || cfg.cfg.configurePgStatStatements) (lib.concatStrings (map (db:
+            (lib.mkIf (cfg.enableAllPreloadedLibraries || cfg.configurePgStatStatements) (lib.concatStrings (map (db:
               (lib.concatMapStringsSep "\n" (ext: /* bash */ ''
                 $PSQL -tAd "${db}" -c "CREATE EXTENSION IF NOT EXISTS ${ext}"
                 $PSQL -tAd "${db}" -c "ALTER EXTENSION ${ext} UPDATE"


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment

Note: I'm not running with `cfg.enableAllPreloadedLibraries` or `cfg.configurePgStatStatements`enabled, so testing this mostly just included checking the settings existed and that my dotfiles built.

Addresses the following build failure:
```shell
… while evaluating the option `system.build.toplevel':
       … while evaluating definitions from `/nix/store/6win34qzpvg1vahlc4iq0nhy1hbh90jg-source/nixos/modules/system/activation/top-level.nix':
       … while evaluating the option `warnings':
       … while evaluating definitions from `/nix/store/6win34qzpvg1vahlc4iq0nhy1hbh90jg-source/nixos/modules/system/boot/systemd.nix':
       … while evaluating the option `systemd.services.postgresql.serviceConfig':
       … while evaluating definitions from `/nix/store/6win34qzpvg1vahlc4iq0nhy1hbh90jg-source/nixos/modules/system/boot/systemd.nix':
       … while evaluating the option `systemd.services.postgresql.postStart':
       … while evaluating definitions from `/nix/store/cx38kwf2qq0ybr0pkinhij8z6x997phv-source/modules/postgres.nix':
       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
       error: attribute 'cfg' missing
       at /nix/store/cx38kwf2qq0ybr0pkinhij8z6x997phv-source/modules/postgres.nix:263:59:
          262|             # based on https://git.catgirl.cloud/999eagle/dotfiles-nix/-/blob/main/modules/system/server/postgres/default.nix#L294-302
          263|             (lib.mkIf (cfg.enableAllPreloadedLibraries || cfg.cfg.configurePgStatStatements) (lib.concatStrings (map (db:
             |                                                           ^
          264|               (lib.concatMapStringsSep "\n" (ext: /* bash */ ''
```