### PR TITLE
nginx: fix common server config

### DIFF
--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -72,9 +72,9 @@ in
           locations = lib.mkOption {
             type = with lib.types; attrsOf (submodule {
               options.extraConfig = lib.mkOption { };
-              config.extraConfig = (if cfg.hstsHeader.enable then /* nginx */ ''
+              config.extraConfig = lib.optionalString cfg.hstsHeader.enable /* nginx */ ''
                 more_set_headers "Strict-Transport-Security: max-age=63072000; ${lib.optionalString cfg.hstsHeader.includeSubDomains "includeSubDomains; "}preload";
-              '' else "") + cfg.commonServerConfig + cfgv.commonLocationsConfig;
+              '' + cfg.commonServerConfig + cfgv.commonLocationsConfig;
             });
           };
         };

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -72,9 +72,9 @@ in
           locations = lib.mkOption {
             type = with lib.types; attrsOf (submodule {
               options.extraConfig = lib.mkOption { };
-              config.extraConfig = lib.mkIf cfg.hstsHeader.enable (/* nginx */ ''
+              config.extraConfig = (if cfg.hstsHeader.enable then /* nginx */ ''
                 more_set_headers "Strict-Transport-Security: max-age=63072000; ${lib.optionalString cfg.hstsHeader.includeSubDomains "includeSubDomains; "}preload";
-              '' + cfg.commonServerConfig + cfgv.commonLocationsConfig);
+              '' else "") + cfg.commonServerConfig + cfgv.commonLocationsConfig;
             });
           };
         };


### PR DESCRIPTION
Don't silently drop common config if hsts is not enabled

## Things done

- [ ] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
