### PR TITLE
nix: use hard coded arguments for nix-store

### DIFF
--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -93,7 +93,7 @@ in
                   ;;
                 # used by nixos-rebuild --target-host ... --build-host ...
                 "nix-store -r")
-                  exec ${lib.getExe' cfg.package "nix-store"} "$@"
+                  exec ${lib.getExe' cfg.package "nix-store"} -r
                   ;;
                 *)
                   echo "Access is only allowed for nix remote building, not running command \"$SSH_ORIGINAL_COMMAND\"" 1>&2


### PR DESCRIPTION
like with the other two code paths

## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
