### PR TITLE
nix: don't require mkForce to change connect-timeout

### DIFF
--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -67,7 +67,7 @@ in
 
     nix.settings = {
       builders-use-substitutes = lib.mkIf cfg.recommendedDefaults true;
-      connect-timeout = lib.mkIf cfg.recommendedDefaults 20;
+      connect-timeout = lib.mkIf cfg.recommendedDefaults (lib.mkDefault 20);
       experimental-features = lib.mkIf cfg.recommendedDefaults [ "nix-command" "flakes" ];
       trusted-users = lib.mkIf cfg.remoteBuilder.enable [ cfg.remoteBuilder.name ];
     };


### PR DESCRIPTION
## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
