### PR TITLE
matrix: use priority instead of regex hacks

### DIFF
--- a/modules/matrix.nix
+++ b/modules/matrix.nix
@@ -166,14 +166,20 @@ in
             forceSSL = lib.mkIf cfg.recommendedDefaults true;
             locations = {
               "= /admin".return = "307 /admin/";
-              "^~ /admin/" = {
+              "/admin/" = {
                 alias = "${cfga.package}/";
+                priority = 500;
                 tryFiles = "$uri $uri/ /index.html";
               };
-              "~ ^/admin/.*\.(?:css|js|jpg|jpeg|gif|png|svg|ico|woff|woff2|ttf|eot|webp)$".extraConfig = /* nginx */ ''
-                expires 30d;
-                more_set_headers "Cache-Control: public";
-              '';
+              "~ ^/admin/.*\\.(?:css|js|jpg|jpeg|gif|png|svg|ico|woff|woff2|ttf|eot|webp)$" = {
+                priority = 400;
+                root = cfga.package;
+                extraConfig = /* nginx */ ''
+                  rewrite ^/admin/(.*)$ /$1 break;
+                  expires 30d;
+                  more_set_headers "Cache-Control: public";
+                '';
+              };
             };
           };
         })


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
