### PR TITLE
nix: decrease connect timeout to 2.29 default

### DIFF
--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -67,7 +67,7 @@ in
 
     nix.settings = {
       builders-use-substitutes = lib.mkIf cfg.recommendedDefaults true;
-      connect-timeout = lib.mkIf cfg.recommendedDefaults (lib.mkDefault 20);
+      connect-timeout = lib.mkIf cfg.recommendedDefaults (lib.mkDefault 5); # Nix 2.29 default
       experimental-features = lib.mkIf cfg.recommendedDefaults [ "nix-command" "flakes" ];
       trusted-users = lib.mkIf cfg.remoteBuilder.enable [ cfg.remoteBuilder.name ];
     };


### PR DESCRIPTION
https://github.com/NixOS/nix/pull/12876

## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
