### PR TITLE
nginx: always use newer nginx version between stable and mainline

### DIFF
--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -170,7 +170,11 @@ in
           if cfg.configureQuic then
             pkgs.nginxQuic
           else
-            pkgs.nginxMainline
+            # use the newer version
+            if lib.versionOlder pkgs.nginx.version pkgs.nginxMainline.version then
+              pkgs.nginxMainline
+            else
+              pkgs.nginx
         ));
 
         recommendedBrotliSettings = lib.mkIf cfg.allRecommendOptions (lib.mkDefault true);


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
