### PR TITLE
nginx: fix commonServerConfig

### DIFF
--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -81,7 +81,10 @@ in
           };
         };
 
-        config.kTLS = lib.mkIf cfg.compileWithAWSlc false;
+        config = {
+          kTLS = lib.mkIf cfg.compileWithAWSlc false;
+          extraConfig = cfg.commonServerConfig;
+        };
       }));
     };
   };


### PR DESCRIPTION
This is broken since fac54f516c6cae5676e48d6d5115687dcacca347

## Things done

- [ ] Made sure, no settings are changed by default
- [ ] Tested changes on a real world deployment
