### PR TITLE
postgres: add empty backupAll option to fix search build

### DIFF
--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -143,6 +143,8 @@ in
     };
 
     postgresqlBackup = lib.optionalAttrs hasPGdumpAllOptions {
+      backupAll = lib.mkOption { };
+
       backupAllExcept = lib.mkOption {
         type = with lib.types; listOf str;
         default = [ ];


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
