### PR TITLE
nix: fix remote build user by configuring usable shell

### DIFF
--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -80,6 +80,10 @@ in
     users.users.${cfg.remoteBuilder.name} = lib.mkIf cfg.remoteBuilder.enable {
       group = "nogroup";
       isSystemUser = true;
+      # sshd runs the forced command from authorizedKeys as `$shell -c ...`, so a
+      # nologin shell (the default for system users) breaks remote building with
+      # "protocol mismatch, got 'This account is currently not available.'"
+      shell = pkgs.bashInteractive;
       openssh.authorizedKeys.keys = map
         (key:
           let

--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -80,8 +80,8 @@ in
     users.users.${cfg.remoteBuilder.name} = lib.mkIf cfg.remoteBuilder.enable {
       group = "nogroup";
       isSystemUser = true;
-      # sshd runs the forced command from authorizedKeys as `$shell -c ...`, so a
-      # nologin shell (the default for system users) breaks remote building with
+      # sshd runs the forced command from authorizedKeys as `$shell -c ...`,
+      # so a nologin shell (the default for system users) breaks remote building with:
       # "protocol mismatch, got 'This account is currently not available.'"
       shell = pkgs.bashInteractive;
       openssh.authorizedKeys.keys = map


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
